### PR TITLE
Store cache in node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
 npm-debug.log
-/.grunt/
+/.cache/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -8,7 +8,7 @@ var fs = require('fs');
  */
 module.exports = function(grunt) {
 
-  var scratch = path.join('.grunt', 'newer', 'scratch');
+  var scratch = path.join('.cache', 'newer', 'scratch');
   var fixtures = path.join(__dirname, 'fixtures');
   var src = '**/*.*';
 
@@ -91,8 +91,8 @@ module.exports = function(grunt) {
         }
       }
     });
-    if (grunt.file.exists('.grunt')) {
-      grunt.file.delete('.grunt');
+    if (grunt.file.exists('.cache')) {
+      grunt.file.delete('.cache');
     }
   });
 

--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -18,7 +18,7 @@ function createTask(grunt, any) {
     }
     var args = Array.prototype.slice.call(arguments, 2).join(':');
     var options = this.options({
-      timestamps: '.grunt'
+      timestamps: path.join(__dirname, '..', '.cache')
     });
     var config = grunt.config.get([name, target]);
     /**


### PR DESCRIPTION
Store the cache in a .cache folder in node_modules/grunt-newer/

That way it's already ignored by most projects and it's removed on upgrade, which is a good thing in case you change the format or something.
