### PR TITLE
Better integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,18 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt --stack --verbose jshint test",
+    "test": "grunt test",
     "start": "grunt watch"
   },
   "devDependencies": {
     "grunt": "0.4.1",
     "grunt-cli": "0.1.9",
     "grunt-contrib-watch": "0.5.3",
-    "grunt-contrib-jshint": "0.6.4"
+    "grunt-contrib-jshint": "0.6.4",
+    "chai": "1.7.2",
+    "grunt-cafe-mocha": "0.1.8",
+    "wrench": "1.5.1",
+    "tmp": "0.0.21"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -1,9 +1,11 @@
 var fs = require('fs');
 var path = require('path');
 
+
 function getStamp(dir, name, target) {
   return path.join(dir, name, target, 'timestamp');
 }
+
 
 function createTask(grunt, any) {
   return function(name, target) {
@@ -21,6 +23,7 @@ function createTask(grunt, any) {
       timestamps: path.join(__dirname, '..', '.cache')
     });
     var config = grunt.config.get([name, target]);
+
     /**
      * Special handling for watch task.  This is a multitask that expects
      * the `files` config to be a string or array of string source paths.
@@ -29,14 +32,16 @@ function createTask(grunt, any) {
     if (typeof config.files === 'string') {
       config.src = [config.files];
       delete config.files;
-      srcFiles = true;
+      srcFiles = false;
     } else if (Array.isArray(config.files) &&
         typeof config.files[0] === 'string') {
       config.src = config.files;
       delete config.files;
-      srcFiles = true;
+      srcFiles = false;
     }
+
     var files = grunt.task.normalizeMultiTaskFiles(config, target);
+
     var newerFiles;
     var stamp = getStamp(options.timestamps, name, target);
     var repeat = grunt.file.exists(stamp);
@@ -53,9 +58,10 @@ function createTask(grunt, any) {
           }
           return newer;
         });
-        return grunt.util._.defaults({src: src}, obj);
+        return {src: src, dest: obj.dest};
       });
     }
+
     /**
      * If we started out with only src files in the files config, transform
      * the newerFiles array into an array of source files.
@@ -87,7 +93,7 @@ function createTask(grunt, any) {
         delete config.dest;
         grunt.config.set([name, target], config);
       }
-      // case 1, 4, or 3
+      // case 1, 3 or 4
       grunt.task.run([
         qualified + (args ? ':' + args : ''),
         'newer-timestamp:' + qualified + ':' + options.timestamps

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,23 @@
+{
+  "curly": true,
+  "eqeqeq": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "trailing": true,
+  "maxlen": 80,
+  "globals": {
+    "exports": true,
+    "before": false,
+    "after": false,
+    "describe": false,
+    "it": false,
+    "module": false,
+    "process": false,
+    "require": false,
+    "__dirname": false
+  }
+}

--- a/test/fixtures/newer-modify-none/gruntfile.js
+++ b/test/fixtures/newer-modify-none/gruntfile.js
@@ -1,0 +1,66 @@
+var path = require('path');
+
+
+/**
+ * @param {Object} grunt Grunt.
+ */
+module.exports = function(grunt) {
+  var log = [];
+
+  grunt.initConfig({
+    newer: {
+      options: {
+        timestamps: path.join(__dirname, '.cache')
+      }
+    },
+    modified: {
+      all: {
+        src: 'src/**/*.js'
+      },
+      none: {
+        src: []
+      }
+    },
+    log: {
+      all: {
+        src: 'src/**/*.js',
+        getLog: function() {
+          return log;
+        }
+      }
+    },
+    assert: {
+      that: {
+        getLog: function() {
+          return log;
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+  grunt.loadTasks('../../../test/tasks');
+
+  grunt.registerTask('default', function() {
+
+    grunt.task.run([
+      // run the task without newer, expect all files
+      'log',
+      'assert:that:modified:all',
+
+      // run the task with newer, expect all files
+      'newer:log',
+      'assert:that:modified:all',
+
+      // HFS+ filesystem mtime resolution
+      'wait:1001',
+
+      // run the task again without modifying any, expect no files
+      'newer:log',
+      'assert:that:modified:none'
+
+    ]);
+
+  });
+
+};

--- a/test/fixtures/newer-modify-none/src/one.js
+++ b/test/fixtures/newer-modify-none/src/one.js
@@ -1,0 +1,1 @@
+var one = 'one';

--- a/test/fixtures/newer-modify-none/src/two.js
+++ b/test/fixtures/newer-modify-none/src/two.js
@@ -1,0 +1,1 @@
+var two = 'two';

--- a/test/fixtures/newer-modify-one/gruntfile.js
+++ b/test/fixtures/newer-modify-one/gruntfile.js
@@ -1,0 +1,80 @@
+var path = require('path');
+
+
+/**
+ * @param {Object} grunt Grunt.
+ */
+module.exports = function(grunt) {
+
+  var log = [];
+
+  grunt.initConfig({
+    newer: {
+      options: {
+        timestamps: path.join(__dirname, '.cache')
+      }
+    },
+    modified: {
+      one: {
+        src: 'src/one.js'
+      },
+      all: {
+        src: 'src/**/*.js'
+      },
+      none: {
+        src: []
+      }
+    },
+    log: {
+      all: {
+        src: 'src/**/*.js',
+        getLog: function() {
+          return log;
+        }
+      }
+    },
+    assert: {
+      that: {
+        getLog: function() {
+          return log;
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+  grunt.loadTasks('../../../test/tasks');
+
+  grunt.registerTask('fail', function() {
+    throw new Error('see above');
+  });
+
+  grunt.registerTask('default', function() {
+
+    grunt.task.run([
+      // run the assert task with newer, expect all files
+      'newer:log',
+      'assert:that:modified:all',
+
+      // HFS+ filesystem mtime resolution
+      'wait:1001',
+
+      // modify one file
+      'modified:one',
+
+      // run assert task again, expect one file
+      'newer:log',
+      'assert:that:modified:one',
+
+      // HFS+ filesystem mtime resolution
+      'wait:1001',
+
+      // modify nothing, expect no files
+      'newer:log',
+      'assert:that:modified:none'
+
+    ]);
+
+  });
+
+};

--- a/test/fixtures/newer-modify-one/src/one.js
+++ b/test/fixtures/newer-modify-one/src/one.js
@@ -1,0 +1,1 @@
+var one = 'one';

--- a/test/fixtures/newer-modify-one/src/two.js
+++ b/test/fixtures/newer-modify-one/src/two.js
@@ -1,0 +1,1 @@
+var two = 'two';

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,115 @@
+var path = require('path');
+var cp = require('child_process');
+var fs = require('fs');
+
+var chai = require('chai');
+var tmp = require('tmp');
+var wrench = require('wrench');
+
+var fixtures = path.join(__dirname, 'fixtures');
+var tmpDir = 'tmp';
+
+
+/**
+ * Spawn a Grunt process.
+ * @param {string} dir Directory with gruntfile.js.
+ * @param {function(Error, Process)} done Callback.
+ */
+function spawnGrunt(dir, done) {
+  var gruntfile = path.join(dir, 'gruntfile.js');
+  if (!fs.existsSync(gruntfile)) {
+    done(new Error('Cannot find gruntfile.js: ' + gruntfile));
+  } else {
+    var node = process.argv[0];
+    var grunt = process.argv[1]; // assumes grunt drives these tests
+    var child = cp.spawn(node, [grunt, '--verbose', '--stack'], {cwd: dir});
+    done(null, child);
+  }
+}
+
+
+/**
+ * Set up before running tests.
+ * @param {string} name Fixture name.
+ * @param {function} done Callback.
+ */
+function cloneFixture(name, done) {
+  var fixture = path.join(fixtures, name);
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir);
+  }
+
+  tmp.dir({dir: tmpDir}, function(error, dir) {
+    if (error) {
+      return done(error);
+    }
+    var scratch = path.join(dir, name);
+    wrench.copyDirRecursive(fixture, scratch, function(error) {
+      done(error, scratch);
+    });
+  });
+}
+
+
+/**
+ * Clone a fixture and run the default Grunt task in it.
+ * @param {string} name Fixture name.
+ * @param {function(Error, scratch)} done Called with an error if the task
+ *     fails.  Called with the cloned fixture directory if the task succeeds.
+ */
+exports.buildFixture = function(name, done) {
+  cloneFixture(name, function(error, scratch) {
+    if (error) {
+      return done(error);
+    }
+    spawnGrunt(scratch, function(error, child) {
+      if (error) {
+        return done(error);
+      }
+      var messages = [];
+      child.stderr.on('data', function(chunk) {
+        messages.push(chunk.toString());
+      });
+      child.stdout.on('data', function(chunk) {
+        messages.push(chunk.toString());
+      });
+      child.on('close', function(code) {
+        if (code !== 0) {
+          done(new Error('Task failed: ' + messages.join('')));
+        } else {
+          done(null, scratch);
+        }
+      });
+    });
+  });
+};
+
+
+/**
+ * Clean up after running tests.
+ * @param {string} scratch Path to scratch directory.
+ * @param {function} done Callback.
+ */
+exports.afterFixture = function(scratch, done) {
+  var error;
+  if (scratch) {
+    try {
+      wrench.rmdirSyncRecursive(scratch, false);
+      wrench.rmdirSyncRecursive(tmpDir, false);
+    } catch (err) {
+      error = err;
+    }
+  }
+  done(error);
+};
+
+
+/** @type {boolean} */
+chai.Assertion.includeStack = true;
+
+
+/**
+ * Chai's assert function configured to include stacks on failure.
+ * @type {function}
+ */
+exports.assert = chai.assert;

--- a/test/newer-modify-none.spec.js
+++ b/test/newer-modify-none.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+
+var helper = require('./helper');
+
+var name = 'newer-modify-none';
+var gruntfile = path.join(name, 'gruntfile.js');
+
+describe(name, function() {
+  var fixture;
+
+  it('runs the default task (see ' + gruntfile + ')', function(done) {
+    this.timeout(2000);
+    helper.buildFixture(name, function(error, dir) {
+      fixture = dir;
+      done(error);
+    });
+  });
+
+  after(function(done) {
+    helper.afterFixture(fixture, done);
+  });
+
+});

--- a/test/newer-modify-one.spec.js
+++ b/test/newer-modify-one.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+
+var helper = require('./helper');
+
+var name = 'newer-modify-one';
+var gruntfile = path.join(name, 'gruntfile.js');
+
+describe(name, function() {
+  var fixture;
+
+  it('runs the default task (see ' + gruntfile + ')', function(done) {
+    this.timeout(3000);
+    helper.buildFixture(name, function(error, dir) {
+      fixture = dir;
+      done(error);
+    });
+  });
+
+  after(function(done) {
+    helper.afterFixture(fixture, done);
+  });
+
+});

--- a/test/tasks/index.js
+++ b/test/tasks/index.js
@@ -1,0 +1,58 @@
+var assert = require('assert');
+var fs = require('fs');
+
+
+/**
+ * Create a clone of the object without the with just src and dest properties.
+ * @param {Object} obj Source object.
+ * @return {Object} Pruned clone.
+ */
+function prune(obj) {
+  return {
+    src: obj.src,
+    dest: obj.dest
+  };
+}
+
+
+/** @param {Object} grunt Grunt. */
+module.exports = function(grunt) {
+
+  grunt.registerMultiTask('assert', function(name, target) {
+    var config = grunt.config([name, target]);
+    var expected = grunt.task.normalizeMultiTaskFiles(config, target)
+        .map(prune);
+    var log = this.data.getLog();
+
+    if (expected.length === 0 || expected[0].src.length === 0) {
+      assert.equal(log.length, 0, 'No log entries');
+    } else {
+      assert.equal(log.length, 1, 'One log entry');
+      var actual = log[0].map(prune);
+      assert.deepEqual(actual, expected);
+      log.length = 0;
+    }
+
+  });
+
+
+  grunt.registerMultiTask('log', function() {
+    var log = this.data.getLog();
+    log.push(this.files.map(prune));
+  });
+
+
+  grunt.registerTask('wait', function(delay) {
+    setTimeout(this.async(), delay);
+  });
+
+
+  grunt.registerMultiTask('modified', function() {
+    this.filesSrc.forEach(function(filepath) {
+      var now = new Date();
+      fs.utimesSync(filepath, now, now);
+      grunt.verbose.writeln('Updating mtime for file: ' + filepath, now);
+    });
+  });
+
+};


### PR DESCRIPTION
Currently, the integration tests are run by chaining together a series of tasks in the main `gruntfile.js`.  This works for some limited cases, but is getting awkward to maintain.  Instead, test fixtures should include their own `gruntfile.js` and assertions should be made after running the default tasks.
