### PR TITLE
Fixed issue with the any-newer task when called in a multitask object

### DIFF
--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -13,7 +13,8 @@ function createTask(grunt, any) {
       var tasks = [];
       Object.keys(grunt.config(name)).forEach(function(target) {
         if (!/^_|^options$/.test(target)) {
-          tasks.push('newer:' + name + ':' + target);
+          var anyPrefix = any ? 'any-' : '';
+          tasks.push(anyPrefix + 'newer:' + name + ':' + target);
         }
       });
       return grunt.task.run(tasks);


### PR DESCRIPTION
When running any-newer task on an object with multiple tasks the "newer" prefix is used instead of the any-newer
