### PR TITLE
newer not working properly with watch

### DIFF
--- a/test/fixtures/newer-reconfigure/gruntfile.js
+++ b/test/fixtures/newer-reconfigure/gruntfile.js
@@ -1,0 +1,100 @@
+var assert = require('assert');
+var path = require('path');
+
+
+/**
+ * @param {Object} grunt Grunt.
+ */
+module.exports = function(grunt) {
+
+  var log = [];
+
+  grunt.initConfig({
+    newer: {
+      options: {
+        timestamps: path.join(__dirname, '.cache')
+      }
+    },
+    modified: {
+      one: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: 'one.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }]
+      },
+      all: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: '**/*.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }]
+      },
+      none: {
+        src: []
+      }
+    },
+    log: {
+      all: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: '**/*.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }],
+        getLog: function() {
+          return log;
+        }
+      }
+    },
+    assert: {
+      that: {
+        getLog: function() {
+          return log;
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+  grunt.loadTasks('../../../test/tasks');
+
+  grunt.registerTask('assert-reconfigured', function() {
+    var config = grunt.config.get(['log', 'all']);
+    assert.deepEqual(Object.keys(config).sort(), ['files', 'getLog']);
+    var files = config.files;
+    assert.equal(files.length, 1);
+    assert.deepEqual(Object.keys(files[0]).sort(),
+        ['cwd', 'dest', 'expand', 'ext', 'src']);
+    assert.equal(files[0].src, '**/*.coffee');
+  });
+
+  grunt.registerTask('default', function() {
+
+    grunt.task.run([
+      // run the log task with newer, expect all files
+      'newer:log',
+      'assert:that:modified:all',
+
+      // HFS+ filesystem mtime resolution
+      'wait:1001',
+
+      // modify one file
+      'modified:one',
+
+      // run assert task again, expect one file
+      'newer:log',
+      'assert:that:modified:one',
+
+      // check that log:all task has been reconfigured with original config
+      'assert-reconfigured'
+    ]);
+
+  });
+
+};

--- a/test/fixtures/newer-reconfigure/src/one.coffee
+++ b/test/fixtures/newer-reconfigure/src/one.coffee
@@ -1,0 +1,3 @@
+coffee =
+  is: 'good'
+  hot: true

--- a/test/fixtures/newer-reconfigure/src/two.coffee
+++ b/test/fixtures/newer-reconfigure/src/two.coffee
@@ -1,0 +1,3 @@
+semicolons = true
+coffee = true
+semicolons = false if coffee

--- a/test/newer-reconfigure.spec.js
+++ b/test/newer-reconfigure.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+
+var helper = require('./helper');
+
+var name = 'newer-reconfigure';
+var gruntfile = path.join(name, 'gruntfile.js');
+
+describe(name, function() {
+  var fixture;
+
+  it('runs the default task (see ' + gruntfile + ')', function(done) {
+    this.timeout(3000);
+    helper.buildFixture(name, function(error, dir) {
+      fixture = dir;
+      done(error);
+    });
+  });
+
+  after(function(done) {
+    helper.afterFixture(fixture, done);
+  });
+
+});


### PR DESCRIPTION
hello,

It seems that the first time newer runs from the watch, it calls grunt.config.set([name, [target], config). here config has the newer files. After that, in all repeat runs, grunt.config.get([name, target]) gets the above set config with only the newer files. Now, if I change any other files that affect this particular task, newer won't pick it up. Please let me know if you need me to send an example grunt config.

Thanks,

Nachiket
