### PR TITLE
Using newer to compile parent Stylus files

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -6,21 +6,42 @@ var async = require('async');
 
 
 /**
+ * Call the callback with `false` in the next tick.
+ * @param {string} src Source file path.
+ * @param {number} time Comparison time.
+ * @param {function(boolean)} callback Called with `false`.
+ */
+function neverNewer(src, time, callback) {
+  process.nextTick(function() {
+    callback(false);
+  });
+}
+
+
+/**
  * Filter a list of files by mtime.
  * @param {Array.<string>} paths List of file paths.
  * @param {Date} time The comparison time.
  * @param {function(Err, Array.<string>)} callback Callback called with any
  *     error and a list of files that have mtimes newer than the provided time.
+ * @param {function(boolean)} isNewer Optional function to determine if a file
+ *     should be considered newer even if the mtime is not newer.
  */
 var filterPathsByTime = exports.filterPathsByTime = function(paths, time,
-    callback) {
-  async.map(paths, fs.stat, function(err, stats) {
-    if (err) {
-      return callback(err);
-    }
-    callback(null, paths.filter(function(filePath, index) {
-      return stats[index].mtime > time;
-    }));
+    callback, isNewer) {
+  isNewer = isNewer || neverNewer;
+  async.filter(paths, function(filepath, include) {
+    fs.stat(filepath, function(err, stats) {
+      if (err) {
+        return callback(err);
+      }
+      if (stats.mtime > time) {
+        return include(true);
+      }
+      isNewer(filepath, time, include);
+    });
+  }, function(results) {
+    callback(null, results);
   });
 };
 
@@ -32,9 +53,12 @@ var filterPathsByTime = exports.filterPathsByTime = function(paths, time,
  * @param {function(Err, boolean)} callback Callback called with any error and
  *     a boolean indicating whether any one of the supplied files is newer than
  *     the comparison time.
+ * @param {function(boolean)} isNewer Optional function to determine if a file
+ *     should be considered newer even if the mtime is not newer.
  */
-var anyNewer = exports.anyNewer = function(paths, time, callback) {
+var anyNewer = exports.anyNewer = function(paths, time, callback, isNewer) {
   var complete = 0;
+  isNewer = isNewer || neverNewer;
   function iterate() {
     fs.stat(paths[complete], function(err, stats) {
       if (err) {
@@ -43,11 +67,17 @@ var anyNewer = exports.anyNewer = function(paths, time, callback) {
       if (stats.mtime > time) {
         return callback(null, true);
       }
-      ++complete;
-      if (complete >= paths.length) {
-        return callback(null, false);
-      }
-      iterate();
+      // one last check to decide whether the file is newer
+      isNewer(paths[complete], time, function(newer) {
+        if (newer) {
+          return callback(null, true);
+        }
+        ++complete;
+        if (complete >= paths.length) {
+          return callback(null, false);
+        }
+        iterate();
+      });
     });
   }
   iterate();
@@ -65,9 +95,11 @@ var anyNewer = exports.anyNewer = function(paths, time, callback) {
  * @param {function(Error, Array.<Object>)} callback Callback called with
  *     modified file config objects.  Objects with no more src files are
  *     filtered from the results.
+ * @param {function(boolean)} isNewer Optional function to determine if a file
+ *     should be considered newer even if the mtime is not newer.
  */
 var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
-    callback) {
+    callback, isNewer) {
   async.map(files, function(obj, done) {
     if (obj.dest) {
       fs.stat(obj.dest, function(err, stats) {
@@ -77,7 +109,7 @@ var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
         }
         return anyNewer(obj.src, stats.mtime, function(err, any) {
           done(err, any && obj);
-        });
+        }, isNewer);
       });
     } else {
       filterPathsByTime(obj.src, previous, function(err, src) {
@@ -85,7 +117,7 @@ var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
           return done(err);
         }
         done(null, {src: src, dest: obj.dest});
-      });
+      }, isNewer);
     }
   }, function(err, results) {
     if (err) {

--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -37,8 +37,16 @@ function createTask(grunt) {
     }
     var args = Array.prototype.slice.call(arguments, 2).join(':');
     var options = this.options({
-      cache: path.join(__dirname, '..', '.cache')
+      cache: path.join(__dirname, '..', '.cache'),
+      isNewer: null
     });
+
+    var isNewer = null;
+    if (options.isNewer) {
+      isNewer = function(src, time, callback) {
+        options.isNewer(name, target, src, time, callback);
+      };
+    }
 
     // support deprecated timestamps option
     if (options.timestamps) {
@@ -122,7 +130,7 @@ function createTask(grunt) {
       grunt.task.run(tasks);
 
       done();
-    });
+    }, isNewer);
 
   };
 }

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 var mock = require('mock-fs');
 var rewire = require('rewire');
 
@@ -59,6 +61,52 @@ describe('util', function() {
         assert.equal(results, undefined);
         done();
       });
+
+    });
+
+    it('accepts a user provided isNewer test (always false)', function(done) {
+
+      var paths = [
+        'src/js/a.js',
+        'src/js/b.js',
+        'src/js/c.js'
+      ];
+
+      var isNewer = function(src, time, callback) {
+        callback(false);
+      };
+
+      util.filterPathsByTime(paths, new Date(250), function(err, results) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(results.length, 1);
+        assert.deepEqual(results.sort(), ['src/js/c.js']);
+        done();
+      }, isNewer);
+
+    });
+
+    it('accepts a user provided isNewer test (true for b.js)', function(done) {
+
+      var paths = [
+        'src/js/a.js',
+        'src/js/b.js',
+        'src/js/c.js'
+      ];
+
+      var isNewer = function(src, time, callback) {
+        callback(path.basename(src) === 'b.js');
+      };
+
+      util.filterPathsByTime(paths, new Date(250), function(err, results) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(results.length, 2);
+        assert.deepEqual(results.sort(), ['src/js/b.js', 'src/js/c.js']);
+        done();
+      }, isNewer);
 
     });
 


### PR DESCRIPTION
Trying to use grunt-newer on a large enterprise site using Stylus, so that we only compile the files necessary, rather than all stylus files every time one is changed.

This is working great, however if a `.styl` file is updated that is imported into parent files, we need to update those as well. Any ideas on how to accomplish that without touching every file that has an `@import` call?
