### PR TITLE
Create newer-clean task to remove cached timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "files"
   ],
   "dependencies": {
-    "async": "0.2.9"
+    "async": "0.2.9",
+    "rimraf": "2.2.4"
   }
 }

--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 
 var async = require('async');
+var rimraf = require('rimraf');
 
 var util = require('../lib/util');
 
@@ -155,6 +156,28 @@ module.exports = function(grunt) {
           grunt.config.set([name, target], pluckConfig(id));
         }
 
+      });
+
+  grunt.registerTask(
+      'newer-clean', 'Remove cached timestamps.', function(name, target) {
+        var done = this.async();
+
+        /**
+         * This intentionally only works with the default cache dir.  If a
+         * custom cache dir is provided, it is up to the user to keep it clean.
+         */
+        var cacheDir = path.join(__dirname, '..', '.cache');
+        if (name && target) {
+          cacheDir = util.getStampPath(cacheDir, name, target);
+        } else if (name) {
+          cacheDir = path.join(cacheDir, name);
+        }
+        if (grunt.file.exists(cacheDir)) {
+          grunt.log.writeln('Cleaning ' + cacheDir);
+          rimraf(cacheDir, done);
+        } else {
+          done();
+        }
       });
 
 };


### PR DESCRIPTION
The `newer-clean` task should remove all cached timestamps.  Called with additional parameters, it should remove timestamps for a specific task and/or target.
