### PR TITLE
Issue when src and dest is the same path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -75,6 +75,15 @@ var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
           // dest file not yet created, use all src files
           return done(null, obj);
         }
+        if (obj.src && obj.src.length === 1 && obj.src[0] === obj.dest) {
+          // when src and dest are same, compare to previous
+          return filterPathsByTime(obj.src, previous, function(err, src) {
+            if (err) {
+              return done(err);
+            }
+            done(null, {src: src, dest: obj.dest});
+          });
+        }
         return anyNewer(obj.src, stats.mtime, function(err, any) {
           done(err, any && obj);
         });

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -187,6 +187,32 @@ describe('util', function() {
       });
     });
 
+    it('provides newer src files if same as dest', function(done) {
+      var files = [{
+        src: ['src/js/a.js'],
+        dest: 'src/js/a.js'
+      }, {
+        src: ['src/js/b.js'],
+        dest: 'src/js/b.js'
+      }, {
+        src: ['src/js/c.js'],
+        dest: 'src/js/c.js'
+      }];
+      util.filterFilesByTime(files, new Date(150), function(err, results) {
+        assert.isNull(err);
+        assert.equal(results.length, 2);
+        var first = results[0];
+        assert.equal(first.dest, 'src/js/b.js');
+        assert.equal(first.src.length, 1);
+        assert.deepEqual(first.src, files[1].src);
+        var second = results[1];
+        assert.equal(second.dest, 'src/js/c.js');
+        assert.equal(second.src.length, 1);
+        assert.deepEqual(second.src, files[2].src);
+        done();
+      });
+    });
+
     it('provides files newer than previous if no dest', function(done) {
       var files = [{
         src: ['src/js/a.js', 'src/js/b.js', 'src/js/c.js']


### PR DESCRIPTION
Hi, thanks for your great plugin, it very helpful!

I notice small issue: it seems to doesn't work when task configured the way when source and destination is the same file.

Example:

```
concat: {
  banner: {
    options: {
      banner: "some banner ..."
    },
    expand: true,
    flatten: false,
    cwd: 'dist',
    src: '*.js',
    dest: 'dist'
  }
}
```

I use `grunt-contrib-concat` to add banners (I know it not very smart, but works). When I try to run `concat` task, configured like this, through `newer` it always handle zero files.

P.S.
Sory for my bad english.
