### PR TITLE
Ability to not overwrite config of a task

### DIFF
--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -148,12 +148,6 @@ module.exports = function(grunt) {
   grunt.registerTask(
       'newer', 'Run a task with only those source files that have been ' +
       'modified since the last successful run.', createTask(grunt));
-      
-  grunt.registerTask(
-      'newer-simple', 'Run a task when any source files have been modified ' +
-      'since the last successful run with original config.', createTask(grunt,
-        {simpleMode: true}
-      ));
 
   var deprecated = 'DEPRECATED TASK.  Use the "newer" task instead';
   grunt.registerTask(


### PR DESCRIPTION
I Propose to add the ability to not overwrite config of a task.
There are a tasks like `grunticon` witch need original config (with all files) to work right - so `grunt-newer` will run full task if any file will change.
To ignore changing config (line 120) need to add in never task options `changeConfig: false`.
You can specify `changeConfig` to all task, or to single taks:

```
newer: {
    options: {
        cache: 'app/cache/grunt',
        changeConfig: false
    }
}
```

or

```
newer: {
    options: {
        cache: 'app/cache/grunt',
        grunticon: {
            changeConfig: false
        }
    }
}
```
