### PR TITLE
When src and dest are the same and one-to-one

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -91,7 +91,7 @@ var anyNewer = exports.anyNewer = function(paths, time, override, callback) {
 var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
     override, callback) {
   async.map(files, function(obj, done) {
-    if (obj.dest) {
+    if (obj.dest && !(obj.src.length === 1 && obj.dest === obj.src[0])) {
       fs.stat(obj.dest, function(err, stats) {
         if (err) {
           // dest file not yet created, use all src files


### PR DESCRIPTION
Now works where src and dest files are the same and there's only one src file (for in-place operations like some grunt-contrib-imagemin use cases.)

Aims to resolve issue #40
