### PR TITLE
Avoid unhandled error when used with aliases

### DIFF
--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -33,6 +33,10 @@ function createTask(grunt) {
     var tasks = [];
     var prefix = this.name;
     if (!targetName) {
+      if (!grunt.config(taskName)) {
+        grunt.fatal('The "' + prefix + '" prefix is not supported for aliases');
+        return;
+      }
       Object.keys(grunt.config(taskName)).forEach(function(targetName) {
         if (!/^_|^options$/.test(targetName)) {
           tasks.push(prefix + ':' + taskName + ':' + targetName);


### PR DESCRIPTION
Grunt doesn't provide an easy way to access the list of tasks associated with an alias.  Instead of an unhandled error, the task should fail.

See #59.
