### PR TITLE
Fixed grunt newer failing to restore configuration

### DIFF
--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -9,6 +9,8 @@ var util = require('../lib/util');
 var counter = 0;
 var configCache = {};
 
+var previous_force_state = null
+
 function cacheConfig(config) {
   ++counter;
   configCache[counter] = config;
@@ -127,8 +129,10 @@ function createTask(grunt) {
       // run the task, and attend to postrun tasks
       var qualified = taskName + ':' + targetName;
       var tasks = [
+        'newer-force:on',
         qualified + (args ? ':' + args : ''),
-        'newer-postrun:' + qualified + ':' + id + ':' + options.cache
+        'newer-force:restore',
+        'newer-postrun:' + qualified + ':' + id + ':' + options.cache,
       ];
       grunt.task.run(tasks);
 
@@ -190,5 +194,15 @@ module.exports = function(grunt) {
           done();
         }
       });
+
+  grunt.registerTask("newer-force", function(set) {
+    if (set === "on") {
+      previous_force_state = grunt.option("force");
+      grunt.option("force", true);
+    }
+    else if (set === "restore") {
+      grunt.option("force", previous_force_state);
+    }
+  });
 
 };


### PR DESCRIPTION
When grunt newer runs a task that fails, it will not restore the configuration leading to numerous silent bugs, especially when running newer on things like watch. Using override will solve this problem as we have no clean way to run post tasks once the main task has failed. This is basically re-creating try finally using force.

If you like this approach to solving the problem, I can create tests so we can get this merged in.

I got the idea for a force task from the comment here, https://github.com/gruntjs/grunt/issues/810#issuecomment-27363230