### PR TITLE
Introduce delegate task

### DIFF
--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -146,11 +146,19 @@ module.exports = function(grunt) {
       'newer', 'Run a task with only those source files that have been ' +
       'modified since the last successful run.', createTask(grunt));
 
-  grunt.registerTask(
+  grunt.registerMultiTask(
       'delegate', 'Delegate a task, that is let grunt-newer check src ' +
       '(and dest) specified in the delegate config, then run the individual ' +
       'task with its own src (and dest).', function() {
-        grunt.task.run(this.args.join(':'));
+        var data = this.data;
+        var task = this.target;
+        var target = Array.prototype.join.call(arguments, ':');
+        if (data.task) {
+          task = data.task;
+        } else if (target) {
+          task = task + ':' + target;
+        }
+        grunt.task.run(task);
       });
 
   var deprecated = 'DEPRECATED TASK.  Use the "newer" task instead';

--- a/tasks/newer.js
+++ b/tasks/newer.js
@@ -146,6 +146,13 @@ module.exports = function(grunt) {
       'newer', 'Run a task with only those source files that have been ' +
       'modified since the last successful run.', createTask(grunt));
 
+  grunt.registerTask(
+      'delegate', 'Delegate a task, that is let grunt-newer check src ' +
+      '(and dest) specified in the delegate config, then run the individual ' +
+      'task with its own src (and dest).', function() {
+        grunt.task.run(this.args.join(':'));
+      });
+
   var deprecated = 'DEPRECATED TASK.  Use the "newer" task instead';
   grunt.registerTask(
       'any-newer', deprecated, function() {


### PR DESCRIPTION
As stated in https://github.com/tschaub/grunt-newer/issues/29#issuecomment-160223515, I added a simple delegation task (named `delegate`). This allows to specifiy for individual tasks `src` (and also `dest`) for newer to check, and then actually run the task with its own `src` ( and `dest`). This is useful for SASS/LESS.

With the following config:
```js
grunt.initConfig( {
	delegate: {
		sass: {
			src: [ 'resources/scss/**/*.scss' ]
		}
	},
	sass: {
		styles: {
			expand: true,
			cwd: 'resources/scss/',
			src: [ '*.scss' ],
			dest: 'assets/css/',
			ext: '.css'
		}
	}
} );
```
one could simply run `grunt newer:delegate:sass:styles` to actually have `sass:styles` be run when there are new `.scss` files (even in subfolders).