### PR TITLE
Update all dependencies to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,50 +2,50 @@
   "name": "grunt-newer",
   "description": "Run Grunt tasks with only those source files modified since the last successful run.",
   "version": "1.1.2",
-  "homepage": "https://github.com/tschaub/grunt-newer",
   "author": {
     "name": "Tim Schaub",
     "url": "http://tschaub.net/"
+  },
+  "bugs": {
+    "url": "https://github.com/tschaub/grunt-newer/issues"
+  },
+  "dependencies": {
+    "async": "^1.5.2",
+    "rimraf": "^2.5.2"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "grunt": "0.4.5",
+    "grunt-cafe-mocha": "0.1.13",
+    "grunt-cli": "^1.1.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "mock-fs": "^3.8.0",
+    "tmp": "0.0.28",
+    "wrench": "1.5.8"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "homepage": "https://github.com/tschaub/grunt-newer",
+  "keywords": [
+    "files",
+    "grunt",
+    "gruntplugin",
+    "newer"
+  ],
+  "license": "MIT",
+  "main": "gruntfile.js",
+  "peerDependencies": {
+    "grunt": ">=0.4.1"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/tschaub/grunt-newer.git"
   },
-  "bugs": {
-    "url": "https://github.com/tschaub/grunt-newer/issues"
-  },
-  "license": "MIT",
-  "main": "gruntfile.js",
-  "engines": {
-    "node": ">= 0.8.0"
-  },
   "scripts": {
-    "test": "grunt test",
-    "start": "grunt test watch"
-  },
-  "devDependencies": {
-    "grunt": "0.4.5",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-watch": "0.6.1",
-    "grunt-contrib-jshint": "0.10.0",
-    "chai": "1.9.2",
-    "grunt-cafe-mocha": "0.1.13",
-    "wrench": "1.5.8",
-    "tmp": "0.0.24",
-    "grunt-contrib-clean": "0.6.0",
-    "mock-fs": "2.x"
-  },
-  "peerDependencies": {
-    "grunt": ">=0.4.1"
-  },
-  "keywords": [
-    "gruntplugin",
-    "grunt",
-    "newer",
-    "files"
-  ],
-  "dependencies": {
-    "async": "0.9.0",
-    "rimraf": "2.2.8"
+    "start": "grunt test watch",
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
When starting to look at fixing #86 I noticed that the tests did not run because of an outdated mock-fs dependency that did not support node 5. I updated all other dependencies too and the tests work fine.

 Given that this project already has tests and travis, it would be a small effort to add greenkeeper so dependency upgrades are tested automatically.