### PR TITLE
Add option to ignore small modification time differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ Example use of the `override` option:
   });
 ```
 
+#### <a id="optionstolerance">options.tolerance</a>
+ * type: `number` (milliseconds)
+ * default: `0`
+
+The `newer` tasks compares the file modification times of the source and destination files with millisecond precision.
+On some file systems this causes destination files to always be considered older because of imprecision in the registration of modification times.
+
+If your tasks are always run even though the source files are not modified use the `tolerance` option to compensate for this imprecision.
+
+In most cases setting the option to `1000` milliseconds should be enough. If the file system is very imprecise use a higher value.
+
+Example use of the `tolerance` option:
+
+```js
+  grunt.initConfig({
+    newer: {
+      options: {
+        tolerance: 1000
+      }
+    }
+  });
+```
+
 ## That's it
 
 Please [submit an issue](https://github.com/tschaub/grunt-newer/issues) if you encounter any trouble.  Contributions or suggestions for improvements welcome!

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,17 +4,19 @@ var path = require('path');
 
 var async = require('async');
 
-
 /**
  * Filter a list of files by mtime.
  * @param {Array.<string>} paths List of file paths.
  * @param {Date} time The comparison time.
+ * @param {number} tolerance Maximum time in milliseconds that the destination
+ *     file is allowed to be newer than the source file to compensate for
+ *     imprecisions in modification times in file systems.
  * @param {function(string, Date, function(boolean))} override Override.
  * @param {function(Err, Array.<string>)} callback Callback called with any
  *     error and a list of files that have mtimes newer than the provided time.
  */
 var filterPathsByTime = exports.filterPathsByTime = function(paths, time,
-    override, callback) {
+    tolerance, override, callback) {
   async.map(paths, fs.stat, function(err, stats) {
     if (err) {
       return callback(err);
@@ -22,7 +24,7 @@ var filterPathsByTime = exports.filterPathsByTime = function(paths, time,
 
     var olderPaths = [];
     var newerPaths = paths.filter(function(filePath, index) {
-      var newer = stats[index].mtime > time;
+      var newer = stats[index].mtime - time > tolerance;
       if (!newer) {
         olderPaths.push(filePath);
       }
@@ -42,12 +44,16 @@ var filterPathsByTime = exports.filterPathsByTime = function(paths, time,
  * Determine if any of the given files are newer than the provided time.
  * @param {Array.<string>} paths List of file paths.
  * @param {Date} time The comparison time.
+ * @param {number} tolerance Maximum time in milliseconds that the destination
+ *     file is allowed to be newer than the source file to compensate for
+ *     imprecisions in modification times in file systems.
  * @param {function(string, Date, function(boolean))} override Override.
  * @param {function(Err, boolean)} callback Callback called with any error and
  *     a boolean indicating whether any one of the supplied files is newer than
  *     the comparison time.
  */
-var anyNewer = exports.anyNewer = function(paths, time, override, callback) {
+var anyNewer = exports.anyNewer = function(paths, time, tolerance, override,
+    callback) {
   if (paths.length === 0) {
     process.nextTick(function() {
       callback(null, false);
@@ -60,7 +66,12 @@ var anyNewer = exports.anyNewer = function(paths, time, override, callback) {
       if (err) {
         return callback(err);
       }
-      if (stats.mtime > time) {
+
+      var pathTime = stats.mtime.getTime();
+      var comparisonTime = time.getTime();
+      var difference = pathTime - comparisonTime;
+
+      if (difference > tolerance) {
         return callback(null, true);
       } else {
         override(paths[complete], time, function(include) {
@@ -89,13 +100,16 @@ var anyNewer = exports.anyNewer = function(paths, time, override, callback) {
  *     are returned from `grunt.task.normalizeMultiTaskFiles` and have a src
  *     property (Array.<string>) and an optional dest property (string).
  * @param {Date} previous Comparison time.
+ * @param {number} tolerance Maximum time in milliseconds that the destination
+ *     file is allowed to be newer than the source file to compensate for
+ *     imprecisions in modification times in file systems.
  * @param {function(string, Date, function(boolean))} override Override.
  * @param {function(Error, Array.<Object>)} callback Callback called with
  *     modified file config objects.  Objects with no more src files are
  *     filtered from the results.
  */
 var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
-    override, callback) {
+    tolerance, override, callback) {
   async.map(files, function(obj, done) {
     if (obj.dest && !(obj.src.length === 1 && obj.dest === obj.src[0])) {
       fs.stat(obj.dest, function(err, stats) {
@@ -103,12 +117,14 @@ var filterFilesByTime = exports.filterFilesByTime = function(files, previous,
           // dest file not yet created, use all src files
           return done(null, obj);
         }
-        return anyNewer(obj.src, stats.mtime, override, function(err, any) {
+        return anyNewer(
+          obj.src, stats.mtime, tolerance, override, function(err, any) {
           done(err, any && obj);
         });
       });
     } else {
-      filterPathsByTime(obj.src, previous, override, function(err, src) {
+      filterPathsByTime(
+          obj.src, previous, tolerance, override, function(err, src) {
         if (err) {
           return done(err);
         }

--- a/test/integration/fixtures/newer-tolerance/gruntfile.js
+++ b/test/integration/fixtures/newer-tolerance/gruntfile.js
@@ -1,0 +1,101 @@
+var assert = require('assert');
+var path = require('path');
+
+
+/**
+ * @param {Object} grunt Grunt.
+ */
+module.exports = function(grunt) {
+
+  var log = [];
+
+  grunt.initConfig({
+    newer: {
+      options: {
+        cache: path.join(__dirname, '.cache'),
+        tolerance: 2000
+      }
+    },
+    modified: {
+      one: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: 'one.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }]
+      },
+      all: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: '**/*.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }]
+      },
+      none: {
+        src: []
+      }
+    },
+    log: {
+      all: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: '**/*.coffee',
+          dest: 'dest/',
+          ext: '.js'
+        }],
+        getLog: function() {
+          return log;
+        }
+      }
+    },
+    assert: {
+      that: {
+        getLog: function() {
+          return log;
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+  grunt.loadTasks('../../../test/integration/tasks');
+
+  grunt.registerTask('assert-reconfigured', function() {
+    var config = grunt.config.get(['log', 'all']);
+    assert.deepEqual(Object.keys(config).sort(), ['files', 'getLog']);
+    var files = config.files;
+    assert.equal(files.length, 1);
+    assert.deepEqual(Object.keys(files[0]).sort(),
+        ['cwd', 'dest', 'expand', 'ext', 'src']);
+    assert.equal(files[0].src, '**/*.coffee');
+  });
+
+  grunt.registerTask('default', function() {
+
+    grunt.task.run([
+      // run the log task with newer, expect all files
+      'newer:log',
+      'assert:that:modified:all',
+
+      // HFS+ filesystem mtime resolution
+      'wait:1001',
+
+      // modify one file
+      'modified:one',
+
+      // run assert task again, expect no files
+      'newer:log',
+      'assert:that:modified:none',
+
+      // check that log:all task has been reconfigured with original config
+      'assert-reconfigured'
+    ]);
+
+  });
+
+};

--- a/test/integration/fixtures/newer-tolerance/src/one.coffee
+++ b/test/integration/fixtures/newer-tolerance/src/one.coffee
@@ -1,0 +1,3 @@
+coffee =
+  is: 'good'
+  hot: true

--- a/test/integration/fixtures/newer-tolerance/src/two.coffee
+++ b/test/integration/fixtures/newer-tolerance/src/two.coffee
@@ -1,0 +1,3 @@
+semicolons = true
+coffee = true
+semicolons = false if coffee

--- a/test/integration/newer-tolerance.spec.js
+++ b/test/integration/newer-tolerance.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+
+var helper = require('../helper');
+
+var name = 'newer-tolerance';
+var gruntfile = path.join(name, 'gruntfile.js');
+
+describe(name, function() {
+  var fixture;
+
+  it('runs the default task (see ' + gruntfile + ')', function(done) {
+    this.timeout(6000);
+    helper.buildFixture(name, function(error, dir) {
+      fixture = dir;
+      done(error);
+    });
+  });
+
+  after(function(done) {
+    helper.afterFixture(fixture, done);
+  });
+
+});

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -39,7 +39,7 @@ describe('util', function() {
         'src/js/c.js'
       ];
 
-      util.filterPathsByTime(paths, new Date(150), nullOverride,
+      util.filterPathsByTime(paths, new Date(150), 0, nullOverride,
           function(err, results) {
         if (err) {
           return done(err);
@@ -65,7 +65,7 @@ describe('util', function() {
         include(false);
       }
 
-      util.filterPathsByTime(paths, new Date(150), customOverride,
+      util.filterPathsByTime(paths, new Date(150), 0, customOverride,
           function(err, results) {
         if (err) {
           return done(err);
@@ -91,7 +91,7 @@ describe('util', function() {
         include(true);
       }
 
-      util.filterPathsByTime(paths, new Date(150), customOverride,
+      util.filterPathsByTime(paths, new Date(150), 0, customOverride,
           function(err, results) {
         if (err) {
           return done(err);
@@ -110,10 +110,31 @@ describe('util', function() {
         'src/bogus-file.js'
       ];
 
-      util.filterPathsByTime(paths, new Date(150), nullOverride,
+      util.filterPathsByTime(paths, new Date(150), 0, nullOverride,
           function(err, results) {
         assert.instanceOf(err, Error);
         assert.equal(results, undefined);
+        done();
+      });
+
+    });
+
+    it('calls callback with files newer than provided time plus tolerance',
+      function(done) {
+
+      var paths = [
+        'src/js/a.js',
+        'src/js/b.js',
+        'src/js/c.js'
+      ];
+
+      util.filterPathsByTime(paths, new Date(150), 100, nullOverride,
+          function(err, results) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(results.length, 1);
+        assert.deepEqual(results, ['src/js/c.js']);
         done();
       });
 
@@ -149,7 +170,8 @@ describe('util', function() {
     ];
 
     it('calls callback with true if any file is newer', function(done) {
-      util.anyNewer(paths, new Date(250), nullOverride, function(err, newer) {
+      util.anyNewer(paths, new Date(250), 0, nullOverride,
+          function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -163,7 +185,7 @@ describe('util', function() {
         done(new Error('Override should not be called'));
       }
 
-      util.anyNewer(paths, new Date(1), override, function(err, newer) {
+      util.anyNewer(paths, new Date(1), 0, override, function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -173,7 +195,8 @@ describe('util', function() {
     });
 
     it('calls callback with false if no files are newer', function(done) {
-      util.anyNewer(paths, new Date(350), nullOverride, function(err, newer) {
+      util.anyNewer(paths, new Date(350), 0, nullOverride,
+          function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -183,7 +206,7 @@ describe('util', function() {
     });
 
     it('calls callback with false if no files are provided', function(done) {
-      util.anyNewer([], new Date(), nullOverride, function(err, newer) {
+      util.anyNewer([], new Date(), 0, nullOverride, function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -199,7 +222,7 @@ describe('util', function() {
         include(false);
       }
 
-      util.anyNewer(paths, new Date(150), override, function(err, newer) {
+      util.anyNewer(paths, new Date(150), 0, override, function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -213,7 +236,7 @@ describe('util', function() {
         include(true);
       }
 
-      util.anyNewer(paths, new Date(1000), override, function(err, newer) {
+      util.anyNewer(paths, new Date(1000), 0, override, function(err, newer) {
         if (err) {
           return done(err);
         }
@@ -223,10 +246,22 @@ describe('util', function() {
     });
 
     it('calls callback with error if file not found', function(done) {
-      util.anyNewer(['bogus/file.js'], new Date(350), nullOverride,
+      util.anyNewer(['bogus/file.js'], new Date(350), 0, nullOverride,
           function(err, newer) {
         assert.instanceOf(err, Error);
         assert.equal(newer, undefined);
+        done();
+      });
+    });
+
+    it('calls callback with false if files are newer than date plus tolerance',
+        function(done) {
+      util.anyNewer(paths, new Date(10), 400, nullOverride,
+          function(err, newer) {
+        if (err) {
+          return done(err);
+        }
+        assert.isFalse(newer);
         done();
       });
     });
@@ -274,7 +309,7 @@ describe('util', function() {
         src: ['src/js/a.js'],
         dest: 'src/js/a.js'
       }];
-      util.filterFilesByTime(files, new Date(50), nullOverride,
+      util.filterFilesByTime(files, new Date(50), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 1);
@@ -290,7 +325,7 @@ describe('util', function() {
         src: ['src/js/a.js'],
         dest: 'src/js/a.js'
       }];
-      util.filterFilesByTime(files, new Date(150), nullOverride,
+      util.filterFilesByTime(files, new Date(150), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 0);
@@ -306,7 +341,7 @@ describe('util', function() {
         src: ['src/js/b.js'],
         dest: 'src/js/b.js'
       }];
-      util.filterFilesByTime(files, new Date(50), nullOverride,
+      util.filterFilesByTime(files, new Date(50), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 2);
@@ -325,7 +360,7 @@ describe('util', function() {
         src: ['src/js/a.js', 'src/js/b.js', 'src/js/c.js'],
         dest: 'dest/js/abc.min.js'
       }];
-      util.filterFilesByTime(files, new Date(1000), nullOverride,
+      util.filterFilesByTime(files, new Date(1000), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 1);
@@ -342,7 +377,7 @@ describe('util', function() {
         src: ['src/js/a.js', 'src/js/b.js', 'src/js/c.js'],
         dest: 'dest/js/foo.min.js'
       }];
-      util.filterFilesByTime(files, new Date(1000), nullOverride,
+      util.filterFilesByTime(files, new Date(1000), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 1);
@@ -365,7 +400,7 @@ describe('util', function() {
         src: ['src/js/c.js'],
         dest: 'src/js/c.js'
       }];
-      util.filterFilesByTime(files, new Date(150), nullOverride,
+      util.filterFilesByTime(files, new Date(150), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 2);
@@ -385,7 +420,7 @@ describe('util', function() {
       var files = [{
         src: ['src/js/a.js', 'src/js/b.js', 'src/js/c.js']
       }];
-      util.filterFilesByTime(files, new Date(200), nullOverride,
+      util.filterFilesByTime(files, new Date(200), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 1);
@@ -404,7 +439,7 @@ describe('util', function() {
         src: ['src/less/two.less'],
         dest: 'dest/css/two.css'
       }];
-      util.filterFilesByTime(files, new Date(1000), nullOverride,
+      util.filterFilesByTime(files, new Date(1000), 0, nullOverride,
           function(err, results) {
         assert.isNull(err);
         assert.equal(results.length, 1);
@@ -420,7 +455,7 @@ describe('util', function() {
         src: ['src/less/bogus.less'],
         dest: 'dest/css/one.css'
       }];
-      util.filterFilesByTime(files, new Date(1000), nullOverride,
+      util.filterFilesByTime(files, new Date(1000), 0, nullOverride,
           function(err, results) {
         assert.instanceOf(err, Error);
         assert.isUndefined(results);


### PR DESCRIPTION
With the new `tolerance` option small differences in modification times between the source and destination files can be ignored.

Fixes #86